### PR TITLE
DND-2130 явно задал параметр однопоточной сборки

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: date-check
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build
         run:
-          bundle exec middleman build --build-dir=site
+          bundle exec middleman build --build-dir=site --no-parallel
 
       - name: Build index
         run: |

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,7 +21,7 @@ Options:
 
 
 run_build() {
-  bundle exec middleman build --clean
+  bundle exec middleman build --clean --no-parallel
 }
 
 parse_args() {


### PR DESCRIPTION
Текущий сборочный движок mini_racer не умеет в параллельную сборку, но middleman докускает ее по умолчанию. Если явно не задать --no-parallel - mini_racer будет пытаться запускаться в параллельном режиме по возможности - и когда "возможность появится" - гарантированно упадет